### PR TITLE
No cast, autorotate, tiffsave

### DIFF
--- a/wrk_vips.pl
+++ b/wrk_vips.pl
@@ -148,7 +148,7 @@ sub process_image
       return undef;
   }
 
-  my @vips= (qw(/usr/bin/vips im_vips2tiff --vips-progress --vips-concurrency=4), $tmp_img.'.v', $out_img.':jpeg:85,tile:256x256,pyramid');
+  my @vips= (qw(/usr/bin/vips tiffsave --vips-progress --vips-concurrency 4), $tmp_img.'.v', $out_img, qw(--tile --pyramid --compression jpeg --Q 85 --tile-width 256 --tile-height 256));
   my $vips= join (' ', @vips);
   print "vips: [$vips]\n";
   my $vips_txt= `@vips 2>&1`;

--- a/wrk_vips.pl
+++ b/wrk_vips.pl
@@ -132,22 +132,6 @@ sub process_image
   my @tmp_st= stat(_);
   # TODO: check ....
 
-  # we have to cast 16bit to 8bit when using jpeg compression
-  my $cast_img = $tmp_img.'.v'; # vips format, see https://github.com/jcupitt/libvips/issues/8#issuecomment-12292039
-  my @cast= (qw(/usr/bin/vips im_msb), $tmp_img, $cast_img);
-  my $cast= join (' ', @cast);
-  print "cast: [$cast]\n";
-  my $cast_txt= `@cast 2>&1`;
-  print "cast_txt=[$cast_txt]\n";
-  my @cast_lines= x_lines ($cast_txt);
-
-  unless (-f $cast_img)
-  {
-      print "ATTN: could not save [$cast_img] using cast=[$cast]\n";
-      return undef;
-  }
-
-
   my @vips= (qw(/usr/bin/vips im_vips2tiff --vips-progress --vips-concurrency=4), $tmp_img.'.v', $out_img.':jpeg:85,tile:256x256,pyramid');
   my $vips= join (' ', @vips);
   print "vips: [$vips]\n";
@@ -163,10 +147,9 @@ sub process_image
   my @out_st= stat(_);
   # TODO: check ....
 
-  unlink ($cast_img);
   unlink ($tmp_img);
 
-  return { 'conversion' => 'ok', 'image' => $out_img, vips_lines => \@vips_lines, curl_lines => \@curl_lines, cast_lines => \@cast_lines };
+  return { 'conversion' => 'ok', 'image' => $out_img, vips_lines => \@vips_lines, curl_lines => \@curl_lines };
 }
 
 sub x_lines


### PR DESCRIPTION
Tested with Vips 8.4.5.
- Removed 16-bit to 8-bit cast as `vips tiffsave` does it automatically when using JPEG compression;
- Added image autorotation using `vips autorot` because images exported by IIPServer lose EXIF Orientation metadata;
- Switched to `vips tiffsave` for pyramidal TIFF creation as it's claimed to be more memory-efficient and fast.